### PR TITLE
Hotfix mapboxgl missing css

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -5,8 +5,6 @@
 
 // External libraries
 @import "bootstrap/scss/bootstrap";
-@import 'mapbox-gl/dist/mapbox-gl';
-@import '@mapbox/mapbox-gl-geocoder/dist/mapbox-gl-geocoder';
 @import "font-awesome-sprockets";
 @import "font-awesome";
 @import "flatpickr/dist/flatpickr";

--- a/app/assets/stylesheets/components/_index.scss
+++ b/app/assets/stylesheets/components/_index.scss
@@ -3,5 +3,5 @@
 @import "avatar";
 @import "navbar";
 @import "card";
-@import "map";
+// @import "map";
 @import "floating_form";

--- a/app/assets/stylesheets/map.scss
+++ b/app/assets/stylesheets/map.scss
@@ -1,0 +1,8 @@
+// This stylesheet only responds to pages with map
+// External libraries
+@import 'mapbox-gl/dist/mapbox-gl';
+@import '@mapbox/mapbox-gl-geocoder/dist/mapbox-gl-geocoder';
+@import url('https://api.tiles.mapbox.com/mapbox-gl-js/v1.11.1/mapbox-gl.css');
+
+// Your CSS partials
+@import 'components/map';

--- a/app/assets/stylesheets/pages/_car_list.scss
+++ b/app/assets/stylesheets/pages/_car_list.scss
@@ -5,10 +5,11 @@
     border: none;
   }
 }
+
 #map {
   position: sticky;
+  background-color: grey;
   top: 0;
   height: 100vh;
-  background-color: grey;
   width: 100%; 
 }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -24,4 +24,13 @@ module ApplicationHelper
 
     Nokogiri::HTML.parse(stars.join).to_html.html_safe
   end
+
+  def handle_missing_mapbox_gl_css
+    # if request.path is cars#index or cars#show path, then load the map.scss
+    mapbox_require_pattern = %r{/cars(/?[0-9]*)?}
+    puts "mapbox should be displayed, #{request.path.match(mapbox_require_pattern)}"
+    return unless request.path.match(mapbox_require_pattern)
+
+    stylesheet_link_tag 'map', media: 'all', 'data-turbolinks-track': 'reload'
+  end
 end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -8,14 +8,12 @@ require("turbolinks").start()
 require("@rails/activestorage").start()
 require("channels")
 
-
 // Uncomment to copy all static images under ../images to the output folder and reference
 // them with the image_pack_tag helper in views (e.g <%= image_pack_tag 'rails.png' %>)
 // or the `imagePath` JavaScript helper below.
 //
 // const images = require.context('../images', true)
 // const imagePath = (name) => images(name, true)
-
 
 // ----------------------------------------------------
 // Note(lewagon): ABOVE IS RAILS DEFAULT CONFIGURATION
@@ -28,13 +26,8 @@ import { initMapbox } from '../plugins/init_mapbox';
 import { initAutocomplete } from '../plugins/init_autocomplete';
 import { initFlatpickr } from "../plugins/init_flatpickr"
 
-// Internal imports, e.g:
-// import { initSelect2 } from '../components/init_select2';
-
 document.addEventListener('turbolinks:load', () => {
-  // Call your functions here, e.g:
-  // initSelect2();
-  initMapbox();
   initAutocomplete();
   initFlatpickr();
+  initMapbox();
 });

--- a/app/javascript/plugins/init_mapbox.js
+++ b/app/javascript/plugins/init_mapbox.js
@@ -29,31 +29,29 @@ const addMarkersToMap = (map, markers) => {
 
 const initMapbox = () => {
   const mapElement = document.getElementById('map');
+  // only build a map if there's a div#map to inject into
+  if (!mapElement) { return; }
+  // console.log("mapEl found, generate map Obj");
 
-  if (mapElement) { // only build a map if there's a div#map to inject into
-    mapboxgl.accessToken = mapElement.dataset.mapboxApiKey;
-    const map = new mapboxgl.Map({
-      container: 'map',
-      style: 'mapbox://styles/mapbox/light-v10'
-    });
-    const markers = JSON.parse(mapElement.dataset.markers);
-    map.addControl(new MapboxGeocoder({ accessToken: mapboxgl.accessToken,
-                                      mapboxgl: mapboxgl }));
+  mapboxgl.accessToken = mapElement.dataset.mapboxApiKey;
+  const map = new mapboxgl.Map({
+    container: mapElement,
+    style: 'mapbox://styles/mapbox/light-v10',
+    attributionControl: false
+  });
+  // console.log("map Obj generated");
+  // console.log(map);
+  // console.log(mapboxgl);
+  map.addControl( new mapboxgl.AttributionControl(), 'bottom-right');
+  map.addControl( new MapboxGeocoder({ accessToken: mapboxgl.accessToken, mapboxgl: mapboxgl }) );
+  // console.log("added Controls to map Obj");
 
-    
-    if (Object.keys(markers).length > 0) {
-      addMarkersToMap(map, markers);
-      fitMapToMarkers(map, markers);
-      map.flyTo({
-        center: [markers[0].lng, markers[0].lat],
-        zoom: 12,
-        essential: true,
-        padding: 70,
-        duration: 3000,
-        essential: true
-      })
-    }
+  const markers = JSON.parse(mapElement.dataset.markers);
+  if (Object.keys(markers).length > 0) {
+    addMarkersToMap(map, markers);
+    fitMapToMarkers(map, markers);
   }
+  // console.log("added Markers to map Obj");
 };
 
 export { initMapbox };

--- a/app/views/cars/index.html.erb
+++ b/app/views/cars/index.html.erb
@@ -1,19 +1,21 @@
+<% if @cars.empty? %>
+  <h4 class="mt-5 text-center"> Sorry, your favorite Classy is not here yet </h4>
+  <h4 class="text-center"> Please try another location or model! </h4>
+  <div class="w-100 text-center"><%= link_to "Search again", root_path %></div>
+<% else %>
 <div class="row"> 
-  <div class="cars-list pr-3 col-12 col-md-6">
-    <ul class="list-group list-group-flush">
-      <% if @cars.empty? %>
-        <h4 class="mt-5 text-center"> Sorry, your favorite Classy is not here yet </h4>
-        <h4 class="text-center"> Please try another location or model! </h4>
-        <%= link_to "Search again", root_path, class: "text-center" %>
-      <% else %>
-        <% @cars.each do |car| %>
-          <li class="list-group-item"><%= render 'components/car_card', car: car %></li>
-        <% end %>
-      <% end %>
-    </ul>
-  </div>
-  <div id="map" class="map mapboxgl-map col-12 col-md-6 d-none d-md-inline"
-       data-markers="<%= @markers.to_json %>"
-       data-mapbox-api-key="<%= ENV['MAPBOX_API_KEY'] %>">
-  </div> 
+    <div class="cars-list pr-3 col-12 col-md-6">
+      <ul class="list-group list-group-flush">
+          <% @cars.each do |car| %>
+            <li class="list-group-item"><%= render "components/car_card", car: car %></li>
+          <% end %>
+      </ul>
+    </div>
+    <div class="col-12 col-md-6 d-none d-md-inline">
+      <div id="map" 
+          data-markers="<%= @markers.to_json %>"
+          data-mapbox-api-key="<%= ENV["MAPBOX_API_KEY"] %>">
+      </div> 
+    </div>
 </div>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,22 +6,19 @@
     <%= csp_meta_tag %>
 
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
-
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload', defer: true %>
   </head>
 
   <body>
     <%= render 'shared/navbar' %>
-    <% if current_page? root_path %>
-      <div class='banner'>
-    <% else %>
-      <div class="container">
-    <% end %>
+    <%# check if it is homepage, yes -> give 'banner' class, no -> give 'container' class  %>
+    <% css_class = (current_page? root_path) ? 'banner' : 'container' %>
+    <div class='<%= css_class %>' >
+      <%= handle_missing_mapbox_gl_css %>
       <%= yield %>
-      <%= render 'shared/flashes' %>
-
     </div>
+    <%= render 'shared/flashes' %>
   </body>
 </html>


### PR DESCRIPTION
ADDITIONS:
an application helper `handle_missing_mapbox_gl_css` to create a stylesheet link calling fox mapbox stylesheets `map.scss`:
`<link href='https://api.tiles.mapbox.com/mapbox-gl-js/v<your-mapbox-gl-version>/mapbox-gl.css' rel='stylesheet' />`
[Source to the fix](https://github.com/visgl/react-map-gl/pull/858).

`map.scss`
this file contains styles for mapbox-gl and mapbox geocoder,
and import of the above fix,
and custom style to map area

----
CHANGES:
removed @import to mapbox related stylesheets in `application.scss`, those stylesheets are now called just-in-time on pages using maps for efficiency purposes
improved Cars#index page, not showing map when there's no search result
`application.html.erb`: simplified layout changes, added `handle_missing_mapbox_gl_css` to **<body>**
`init_mapbox.js`: removed map #FlyTo animation -> not bring extra value to map experience; added attribution button on the bottom-right side of map -> condensed mapbox watermark info into 1 small button
